### PR TITLE
FIxed requiring of vertebrae/events

### DIFF
--- a/store.js
+++ b/store.js
@@ -1,5 +1,5 @@
 var extend = require('vertebrae/utils').extend;
-var Events = require('vertebrae/Events');
+var Events = require('vertebrae/events');
 require('native-promise-only');
 
 function createCacheKey(store) {


### PR DESCRIPTION
npm can't find vertebrae/Events but it can find vertebrae/events, because that's the correct folder name